### PR TITLE
c.config_file_path is freed in lib/lwan_shutdown

### DIFF
--- a/src/bin/lwan/main.c
+++ b/src/bin/lwan/main.c
@@ -260,7 +260,6 @@ main(int argc, char *argv[])
 
 out:
     free(c.listener);
-    free(c.config_file_path);
     free((char *)sj.user_name);
 
     return ret;


### PR DESCRIPTION
free(c.config_file_path) in src/bin/lwan/main.c - after lwan_shutdown() 
in lib/lwan.c  free(l->config.config_file_path);  

passing a command-line parameter for the config triggers a core dump.