### PR TITLE
remove free(c.listener/config_file_path) in out:

### DIFF
--- a/src/bin/lwan/main.c
+++ b/src/bin/lwan/main.c
@@ -259,8 +259,6 @@ main(int argc, char *argv[])
     lwan_shutdown(&l);
 
 out:
-    free(c.listener);
-    free(c.config_file_path);
     free((char *)sj.user_name);
 
     return ret;


### PR DESCRIPTION
since listener/config_file_path memory-allocation occurs only after freeing the existing values - the lib/lwan_shutdown is the correct place to free them.